### PR TITLE
FIX: Personal site link, default image source

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -26,7 +26,10 @@
 
 					<div id="icon-container">
 						<!-- ons icoontje: pixel -->
-						<img id="icon" src="" alt="" />
+						<img
+							id="icon"
+							src="https://i.pinimg.com/736x/2d/eb/78/2deb78faa3503eb4a3df9e59c30ae744.jpg"
+							alt="icon" />
 					</div>
 
 					<section id="about-me-container">

--- a/docs/team.json
+++ b/docs/team.json
@@ -3,7 +3,7 @@
     "members": [
         {
             "name" : "brianne",
-            "personalSite" : "https://raw.githubusercontent.com/briannededeugd/web-app-from-scratch-2324/main/docs/data/data.json",
+            "personalSite" : "https://briannededeugd.github.io/web-app-from-scratch-2324/",
             "personalPage": "https://raw.githubusercontent.com/briannededeugd/web-app-from-scratch-2324/main/data.json"
         },
         {


### PR DESCRIPTION
The empty state needed an image and my personal site link was wrong, so I fixed both.